### PR TITLE
WinHTTP JNA interface: Remove comment about having to free memory

### DIFF
--- a/src/main/java/com/github/markusbernhardt/proxy/jna/win/WinHttp.java
+++ b/src/main/java/com/github/markusbernhardt/proxy/jna/win/WinHttp.java
@@ -69,8 +69,8 @@ public interface WinHttp extends StdCallLibrary {
 	 * @param ppwszAutoConfigUrl
 	 *            A data type that returns a pointer to a null-terminated
 	 *            Unicode string that contains the configuration URL that
-	 *            receives the proxy data. You must free the string pointed to
-	 *            by ppwszAutoConfigUrl using the GlobalFree function.
+	 *            receives the proxy data.
+         * 
 	 * @return {@code true} if successful; otherwise, {@code false}.
 	 */
 	boolean WinHttpDetectAutoProxyConfigUrl(WinDef.DWORD dwAutoDetectFlags, WTypes.LPWSTR ppwszAutoConfigUrl);


### PR DESCRIPTION
Remove comment about having to free memory.  The comment was originally copy-pasted from Microsoft's documentation and applies to development in C, C++ or with JNI. However, when using JNA there's no need for developer to free any memory as this is handled by JNA lib and the comment is therefore misleading / redundant.