### PR TITLE
Fixes bug in calling Windows function WinHttpDetectAutoProxyConfigUrl

### DIFF
--- a/src/main/java/com/github/markusbernhardt/proxy/jna/win/WTypes2.java
+++ b/src/main/java/com/github/markusbernhardt/proxy/jna/win/WTypes2.java
@@ -1,0 +1,100 @@
+package com.github.markusbernhardt.proxy.jna.win;
+
+import com.github.markusbernhardt.proxy.util.Logger;
+import com.sun.jna.Pointer;
+import com.sun.jna.platform.win32.Kernel32;
+import com.sun.jna.platform.win32.WTypes;
+import com.sun.jna.ptr.ByReference;
+
+/**
+ * Pointer wrapper classes for various Windows SDK types. The JNA {@code WTypes} 
+ * class already have a few of these, but oddly not for all.
+ * 
+ * <p>
+ * TODO: Implement pointer wrapper classes for more WTypes, if and when needed.
+ * 
+ * @author phansson
+ */
+public class WTypes2 {
+    
+    private WTypes2() {}
+
+    /**
+     * A pointer to a LPWSTR.
+     *
+     * <p>
+     * LPWSTR is itself a pointer, so a pointer to an LPWSTR is really a
+     * pointer-to-pointer. This class hides this complexity and also takes care
+     * of memory disposal.
+     *
+     * <p>
+     * The class is useful where the Windows function <i>returns</i> a result
+     * into a variable of type {@code LPWSTR*}. The class currently has no
+     * setters so it isn't useful for the opposite case, i.e. where a Windows
+     * function <i>accepts</i> a {@code LPWSTR*} as its input.
+     *
+     *
+     * @author phansson
+     */
+    public static class LPWSTRByReference extends ByReference {
+
+        public LPWSTRByReference() {
+            super(Pointer.SIZE);
+        }
+
+        /**
+         * Gets the LPWSTR from this pointer. In general its a lot more
+         * convenient simply to use {@link getString()}.      
+         */
+        public WTypes.LPWSTR getValue() {
+            Pointer p = getPointerToString();
+            if (p == null) {
+                return null;
+            }
+            WTypes.LPWSTR h = new WTypes.LPWSTR(p);
+            return h;
+        }
+
+        /**
+         * Gets the string as pointed to by the LPWSTR or {@code null} if
+         * there's no LPWSTR.
+         */
+        public String getString() {
+            return getValue() == null ? null : getValue().getValue();
+        }
+
+        private Pointer getPointerToString() {
+            return getPointer().getPointer(0);
+        }
+
+        /**
+         * Memory disposal.
+         *
+         * @throws Throwable
+         */
+        @Override
+        protected void finalize() throws Throwable {
+            try {
+                // Free the memory occupied by the string returned
+                // from the Win32 function.
+                Pointer strPointer = getPointerToString();
+                if (strPointer != null) {
+                    Pointer result = Kernel32.INSTANCE.GlobalFree(strPointer);
+                    if (result != null) {
+                        // The call to GlobalFree has failed. This should never
+                        // happen. If it really does happen, there isn't much we 
+                        // can do about it other than logging it.
+                        Logger.log(getClass(), Logger.LogLevel.ERROR,
+                                "Windows function GlobalFree failed while freeing memory for {0} object", 
+                                getClass().getSimpleName());
+                    }
+                }
+            } finally {
+                // This will free the memory of the pointer-to-pointer
+                super.finalize();
+            }
+        }
+
+    }
+
+}

--- a/src/main/java/com/github/markusbernhardt/proxy/jna/win/WinHttp.java
+++ b/src/main/java/com/github/markusbernhardt/proxy/jna/win/WinHttp.java
@@ -1,5 +1,6 @@
 package com.github.markusbernhardt.proxy.jna.win;
 
+import com.sun.jna.LastErrorException;
 import com.sun.jna.Native;
 import com.sun.jna.platform.win32.WTypes;
 import com.sun.jna.platform.win32.WinDef;
@@ -31,6 +32,13 @@ public interface WinHttp extends StdCallLibrary {
 	 */
 	int WINHTTP_ACCESS_TYPE_DEFAULT_PROXY = 0;
 
+        /**
+         * Returned if WinHTTP was unable to discover the URL of the 
+         * Proxy Auto-Configuration (PAC) file using the WPAD method.
+         */
+        int ERROR_WINHTTP_AUTODETECTION_FAILED = 12180;
+        
+        
 	/**
 	 * Retrieves the static proxy or direct configuration from the registry.
 	 * WINHTTP_ACCESS_TYPE_DEFAULT_PROXY does not inherit browser proxy
@@ -71,9 +79,13 @@ public interface WinHttp extends StdCallLibrary {
 	 *            Unicode string that contains the configuration URL that
 	 *            receives the proxy data. You must free the string pointed to
 	 *            by ppwszAutoConfigUrl using the GlobalFree function.
+         * 
 	 * @return {@code true} if successful; otherwise, {@code false}.
+         * @see WinHttpHelpers#detectAutoProxyConfigUrl
 	 */
-	boolean WinHttpDetectAutoProxyConfigUrl(WinDef.DWORD dwAutoDetectFlags, WTypes.LPWSTR ppwszAutoConfigUrl);
+	boolean WinHttpDetectAutoProxyConfigUrl(
+                WinDef.DWORD dwAutoDetectFlags, 
+                WTypes2.LPWSTRByReference ppwszAutoConfigUrl) throws LastErrorException;
 
 	/**
 	 * The WinHttpGetDefaultProxyConfiguration function retrieves the default

--- a/src/main/java/com/github/markusbernhardt/proxy/jna/win/WinHttpHelpers.java
+++ b/src/main/java/com/github/markusbernhardt/proxy/jna/win/WinHttpHelpers.java
@@ -1,0 +1,72 @@
+package com.github.markusbernhardt.proxy.jna.win;
+
+import com.github.markusbernhardt.proxy.util.Logger;
+import com.sun.jna.LastErrorException;
+import com.sun.jna.platform.win32.WinDef;
+
+/**
+ * Static helper methods for Windows {@code WinHttp} functions.
+ * 
+ * @author phansson
+ */
+public class WinHttpHelpers {
+
+            
+    private WinHttpHelpers() {
+    }
+
+    
+
+    /**
+     * Finds the URL for the Proxy Auto-Configuration (PAC) file using WPAD.
+     * This is merely a wrapper around {@link WinHttp#WinHttpDetectAutoProxyConfigUrl(com.sun.jna.platform.win32.WinDef.DWORD, com.github.markusbernhardt.proxy.jna.win.WTypes2.LPWSTRByReference) WinHttpDetectAutoProxyConfigUrl}
+     *
+     * <p>
+     * This method is blocking and may take some time to execute. 
+     * 
+     * @param dwAutoDetectFlags
+     * @return the url of the PAC file or {@code null} if it cannot be located
+     * using WPAD method.
+     */
+    public static String detectAutoProxyConfigUrl(WinDef.DWORD dwAutoDetectFlags) {
+
+        WTypes2.LPWSTRByReference ppwszAutoConfigUrl = new WTypes2.LPWSTRByReference();
+        boolean result = false;
+        try {
+            result = WinHttp.INSTANCE.WinHttpDetectAutoProxyConfigUrl(dwAutoDetectFlags, ppwszAutoConfigUrl);
+        } catch (LastErrorException ex) {
+            if (ex.getErrorCode() == WinHttp.ERROR_WINHTTP_AUTODETECTION_FAILED) {
+                // This error is to be expected. It just means that the lookup 
+                // using either DHCP, DNS or both, failed because there wasn't 
+                // a useful reply from DHCP / DNS. (meaning the site hasn't
+                // configured their DHCP Server or their DNS Server for WPAD)
+                return null;
+            }
+            // Something more serious is wrong. There isn't much we can do
+            // about it but at least we would like to log it.
+            Logger.log(WinHttpHelpers.class, Logger.LogLevel.ERROR, 
+                    "Windows function WinHttpDetectAutoProxyConfigUrl returned error : {0}", ex.getMessage());
+            return null;
+        }
+        if (result) {
+            return ppwszAutoConfigUrl.getString();
+        } else {
+            return null;
+        }
+    }
+    
+    
+    
+    private String sanitizeUrl(String urlStr) {
+        
+        String u = urlStr.trim();
+        int pos = u.indexOf('\n');
+        if (pos == 0) {
+            return "";
+        }
+        if (pos > 0) {
+            return u.substring(0, pos);
+        }
+        return u;
+    }
+}

--- a/src/main/java/com/github/markusbernhardt/proxy/search/browser/ie/IEProxySearchStrategy.java
+++ b/src/main/java/com/github/markusbernhardt/proxy/search/browser/ie/IEProxySearchStrategy.java
@@ -8,8 +8,10 @@ import java.util.List;
 import java.util.Properties;
 
 import com.github.markusbernhardt.proxy.ProxySearchStrategy;
+import com.github.markusbernhardt.proxy.jna.win.WTypes2;
 import com.github.markusbernhardt.proxy.jna.win.WinHttp;
 import com.github.markusbernhardt.proxy.jna.win.WinHttpCurrentUserIEProxyConfig;
+import com.github.markusbernhardt.proxy.jna.win.WinHttpHelpers;
 import com.github.markusbernhardt.proxy.selector.fixed.FixedProxySelector;
 import com.github.markusbernhardt.proxy.selector.misc.ProtocolDispatchSelector;
 import com.github.markusbernhardt.proxy.selector.pac.PacProxySelector;
@@ -104,11 +106,7 @@ public class IEProxySearchStrategy implements ProxySearchStrategy {
 			// This will take some time.
 			DWORD dwAutoDetectFlags = new DWORD(
 			        WinHttp.WINHTTP_AUTO_DETECT_TYPE_DHCP | WinHttp.WINHTTP_AUTO_DETECT_TYPE_DNS_A);
-			LPWSTR ppwszAutoConfigUrl = new LPWSTR();
-			boolean result = WinHttp.INSTANCE.WinHttpDetectAutoProxyConfigUrl(dwAutoDetectFlags, ppwszAutoConfigUrl);
-			if (result) {
-				pacUrl = ppwszAutoConfigUrl.getValue();
-			}
+                        pacUrl = WinHttpHelpers.detectAutoProxyConfigUrl(dwAutoDetectFlags);
 		}
 		if (pacUrl == null) {
 			pacUrl = ieProxyConfig.getAutoConfigUrl();


### PR DESCRIPTION
The current function call to `WinHttpDetectAutoProxyConfigUrl` is broken because it misses the point that the 2nd argument is *a pointer* to a LPWSTR, not a LPWSTR itself. This pull request fixes this and thus thereby fixes issue #6.

I've created a convenience class which represents *a pointer to a LPWSTR*.  JNA already contains a fair amount of these convenience classes (in `WTypes` class) but it seems nobody has ever bothered to write exactly this convenience class. For proxy-vole project it may seem a bit overkill to have such a class as it is (currently) only used in a single case and will probably not be used for any future use cases. Nevertheless it makes the code a bit more readable. The convenience class also takes care of memory disposal of the string which the Win SDK allocates.

There's also now a wrapper method around `WinHttpDetectAutoProxyConfigUrl` which logs if there's any error from Windows while calling the function and correctly avoids treating `ERROR_WINHTTP_AUTODETECTION_FAILED` as a real error.

