### PR TITLE
Implement WinHttpGetDefaultProxyConfiguration for the Windows search strategy

### DIFF
--- a/src/main/java/com/github/markusbernhardt/proxy/search/browser/ie/IEProxySearchStrategy.java
+++ b/src/main/java/com/github/markusbernhardt/proxy/search/browser/ie/IEProxySearchStrategy.java
@@ -1,24 +1,17 @@
 package com.github.markusbernhardt.proxy.search.browser.ie;
 
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
 import java.net.ProxySelector;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Properties;
 
-import com.github.markusbernhardt.proxy.ProxySearchStrategy;
 import com.github.markusbernhardt.proxy.jna.win.WinHttp;
 import com.github.markusbernhardt.proxy.jna.win.WinHttpCurrentUserIEProxyConfig;
-import com.github.markusbernhardt.proxy.selector.fixed.FixedProxySelector;
+import com.github.markusbernhardt.proxy.search.desktop.win.CommonWindowsSearchStrategy;
 import com.github.markusbernhardt.proxy.selector.misc.ProtocolDispatchSelector;
 import com.github.markusbernhardt.proxy.selector.pac.PacProxySelector;
-import com.github.markusbernhardt.proxy.selector.whitelist.ProxyBypassListSelector;
 import com.github.markusbernhardt.proxy.util.Logger;
 import com.github.markusbernhardt.proxy.util.Logger.LogLevel;
 import com.github.markusbernhardt.proxy.util.ProxyException;
 import com.github.markusbernhardt.proxy.util.ProxyUtil;
-import com.github.markusbernhardt.proxy.util.UriFilter;
 import com.sun.jna.platform.win32.WTypes.LPWSTR;
 import com.sun.jna.platform.win32.WinDef.DWORD;
 
@@ -29,7 +22,7 @@ import com.sun.jna.platform.win32.WinDef.DWORD;
  * @author Bernd Rosstauscher (proxyvole@rosstauscher.de) Copyright 2009
  ****************************************************************************/
 
-public class IEProxySearchStrategy implements ProxySearchStrategy {
+public class IEProxySearchStrategy extends CommonWindowsSearchStrategy {
 
 	/*************************************************************************
 	 * getProxySelector
@@ -149,118 +142,10 @@ public class IEProxySearchStrategy implements ProxySearchStrategy {
 
 		Properties p = parseProxyList(proxyString);
 
-		ProtocolDispatchSelector ps = new ProtocolDispatchSelector();
-		addSelectorForProtocol(p, "http", ps);
-		addSelectorForProtocol(p, "https", ps);
-		addSelectorForProtocol(p, "ftp", ps);
-		addSelectorForProtocol(p, "gopher", ps);
-		addSelectorForProtocol(p, "socks", ps);
-		addFallbackSelector(p, ps);
+		ProtocolDispatchSelector ps = buildProtocolDispatchSelector(p);
 
 		ProxySelector result = setByPassListOnSelector(bypassList, ps);
 		return result;
-	}
-
-	/*************************************************************************
-	 * Installs the proxy exclude list on the given selector.
-	 * 
-	 * @param bypassList
-	 *            the list of urls / hostnames to ignore.
-	 * @param ps
-	 *            the proxy selector to wrap.
-	 * @return a wrapped proxy selector that will handle the bypass list.
-	 ************************************************************************/
-
-	private ProxySelector setByPassListOnSelector(String bypassList, ProtocolDispatchSelector ps) {
-		if (bypassList != null && bypassList.trim().length() > 0) {
-			ProxyBypassListSelector result;
-			if ("<local>".equals(bypassList.trim())) {
-				result = buildLocalBypassSelector(ps);
-			} else {
-				bypassList = bypassList.replace(';', ',');
-				result = new ProxyBypassListSelector(bypassList, ps);
-			}
-			return result;
-		}
-		return ps;
-	}
-
-	/*************************************************************************
-	 * Wraps the given selector to handle "local" addresses
-	 * 
-	 * @param ps
-	 *            the proxy selector to wrap.
-	 * @return a wrapped proxy selector that will handle the local addresses.
-	 ************************************************************************/
-
-	private ProxyBypassListSelector buildLocalBypassSelector(ProtocolDispatchSelector ps) {
-		List<UriFilter> localBypassFilter = new ArrayList<UriFilter>();
-		localBypassFilter.add(new IELocalByPassFilter());
-		return new ProxyBypassListSelector(localBypassFilter, ps);
-	}
-
-	/*************************************************************************
-	 * Installs a fallback selector that is used whenever no protocol specific
-	 * selector is defined.
-	 * 
-	 * @param settings
-	 *            to take the proxy settings from.
-	 * @param ps
-	 *            to install the created selector on.
-	 ************************************************************************/
-
-	private void addFallbackSelector(Properties settings, ProtocolDispatchSelector ps) {
-		String proxy = settings.getProperty("default");
-		if (proxy != null) {
-			ps.setFallbackSelector(ProxyUtil.parseProxySettings(proxy));
-		}
-	}
-
-	/*************************************************************************
-	 * Creates a selector for a given protocol. The proxy will be taken from the
-	 * settings and installed on the dispatch selector.
-	 * 
-	 * @param settings
-	 *            to take the proxy settings from.
-	 * @param protocol
-	 *            to create a selector for.
-	 * @param ps
-	 *            to install the created selector on.
-	 ************************************************************************/
-
-	private void addSelectorForProtocol(Properties settings, String protocol, ProtocolDispatchSelector ps) {
-		String proxy = settings.getProperty(protocol);
-		if (proxy != null) {
-			FixedProxySelector protocolSelector = ProxyUtil.parseProxySettings(proxy);
-			ps.setSelector(protocol, protocolSelector);
-		}
-	}
-
-	/*************************************************************************
-	 * Parses the proxy list and splits it by protocol.
-	 * 
-	 * @param proxyString
-	 *            the proxy list string
-	 * @return Properties with separated settings.
-	 * @throws ProxyException
-	 *             on parse error.
-	 ************************************************************************/
-
-	private Properties parseProxyList(String proxyString) throws ProxyException {
-		Properties p = new Properties();
-		if (proxyString.indexOf('=') == -1) {
-			p.setProperty("default", proxyString);
-		} else {
-			try {
-				proxyString = proxyString.replace(';', '\n');
-				p.load(new ByteArrayInputStream(proxyString.getBytes("ISO-8859-1")));
-			} catch (IOException e) {
-				Logger.log(getClass(), LogLevel.ERROR, "Error reading IE settings as properties: {0}", e);
-
-				throw new ProxyException(e);
-			}
-		}
-		return p;
 	}
 
 }

--- a/src/main/java/com/github/markusbernhardt/proxy/search/desktop/win/CommonWindowsSearchStrategy.java
+++ b/src/main/java/com/github/markusbernhardt/proxy/search/desktop/win/CommonWindowsSearchStrategy.java
@@ -1,0 +1,138 @@
+package com.github.markusbernhardt.proxy.search.desktop.win;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.net.ProxySelector;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
+
+import com.github.markusbernhardt.proxy.ProxySearchStrategy;
+import com.github.markusbernhardt.proxy.search.browser.ie.IELocalByPassFilter;
+import com.github.markusbernhardt.proxy.selector.fixed.FixedProxySelector;
+import com.github.markusbernhardt.proxy.selector.misc.ProtocolDispatchSelector;
+import com.github.markusbernhardt.proxy.selector.whitelist.ProxyBypassListSelector;
+import com.github.markusbernhardt.proxy.util.Logger;
+import com.github.markusbernhardt.proxy.util.Logger.LogLevel;
+import com.github.markusbernhardt.proxy.util.ProxyException;
+import com.github.markusbernhardt.proxy.util.ProxyUtil;
+import com.github.markusbernhardt.proxy.util.UriFilter;
+
+/**
+ * Contains common methods used in search strategies for both Windows and IE.
+ */
+public abstract class CommonWindowsSearchStrategy implements ProxySearchStrategy {
+
+	/*************************************************************************
+	 * Installs the proxy exclude list on the given selector.
+	 *
+	 * @param bypassList
+	 *            the list of urls / hostnames to ignore.
+	 * @param ps
+	 *            the proxy selector to wrap.
+	 * @return a wrapped proxy selector that will handle the bypass list.
+	 ************************************************************************/
+
+	protected ProxySelector setByPassListOnSelector(String bypassList, ProtocolDispatchSelector ps) {
+		if (bypassList != null && bypassList.trim().length() > 0) {
+			ProxyBypassListSelector result;
+			if ("<local>".equals(bypassList.trim())) {
+				result = buildLocalBypassSelector(ps);
+			} else {
+				bypassList = bypassList.replace(';', ',');
+				result = new ProxyBypassListSelector(bypassList, ps);
+			}
+			return result;
+		}
+		return ps;
+	}
+
+	/*************************************************************************
+	 * Wraps the given selector to handle "local" addresses
+	 *
+	 * @param ps
+	 *            the proxy selector to wrap.
+	 * @return a wrapped proxy selector that will handle the local addresses.
+	 ************************************************************************/
+
+	private ProxyBypassListSelector buildLocalBypassSelector(ProtocolDispatchSelector ps) {
+		List<UriFilter> localBypassFilter = new ArrayList<UriFilter>();
+		localBypassFilter.add(new IELocalByPassFilter());
+		return new ProxyBypassListSelector(localBypassFilter, ps);
+	}
+
+	/*************************************************************************
+	 * Installs a fallback selector that is used whenever no protocol specific
+	 * selector is defined.
+	 *
+	 * @param settings
+	 *            to take the proxy settings from.
+	 * @param ps
+	 *            to install the created selector on.
+	 ************************************************************************/
+
+	private void addFallbackSelector(Properties settings, ProtocolDispatchSelector ps) {
+		String proxy = settings.getProperty("default");
+		if (proxy != null) {
+			ps.setFallbackSelector(ProxyUtil.parseProxySettings(proxy));
+		}
+	}
+
+	/*************************************************************************
+	 * Creates a selector for a given protocol. The proxy will be taken from the
+	 * settings and installed on the dispatch selector.
+	 *
+	 * @param settings
+	 *            to take the proxy settings from.
+	 * @param protocol
+	 *            to create a selector for.
+	 * @param ps
+	 *            to install the created selector on.
+	 ************************************************************************/
+
+	private void addSelectorForProtocol(Properties settings, String protocol, ProtocolDispatchSelector ps) {
+		String proxy = settings.getProperty(protocol);
+		if (proxy != null) {
+			FixedProxySelector protocolSelector = ProxyUtil.parseProxySettings(proxy);
+			ps.setSelector(protocol, protocolSelector);
+		}
+	}
+
+	/*************************************************************************
+	 * Parses the proxy list and splits it by protocol.
+	 *
+	 * @param proxyString
+	 *            the proxy list string
+	 * @return Properties with separated settings.
+	 * @throws ProxyException
+	 *             on parse error.
+	 ************************************************************************/
+
+	protected Properties parseProxyList(String proxyString) throws ProxyException {
+		Properties p = new Properties();
+		if (proxyString.indexOf('=') == -1) {
+			p.setProperty("default", proxyString);
+		} else {
+			try {
+				proxyString = proxyString.replace(';', '\n');
+				p.load(new ByteArrayInputStream(proxyString.getBytes("ISO-8859-1")));
+			} catch (IOException e) {
+				Logger.log(getClass(), LogLevel.ERROR, "Error reading IE settings as properties: {0}", e);
+
+				throw new ProxyException(e);
+			}
+		}
+		return p;
+	}
+
+	protected ProtocolDispatchSelector buildProtocolDispatchSelector(Properties properties) {
+		ProtocolDispatchSelector ps = new ProtocolDispatchSelector();
+		addSelectorForProtocol(properties, "http", ps);
+		addSelectorForProtocol(properties, "https", ps);
+		addSelectorForProtocol(properties, "ftp", ps);
+		addSelectorForProtocol(properties, "gopher", ps);
+		addSelectorForProtocol(properties, "socks", ps);
+		addFallbackSelector(properties, ps);
+		return ps;
+	}
+}

--- a/src/main/java/com/github/markusbernhardt/proxy/search/desktop/win/WinProxyConfig.java
+++ b/src/main/java/com/github/markusbernhardt/proxy/search/desktop/win/WinProxyConfig.java
@@ -1,0 +1,58 @@
+package com.github.markusbernhardt.proxy.search.desktop.win;
+
+public class WinProxyConfig {
+
+	/*****************************************************************************
+	 * Proxy settings container used for the native methods. Will contain the
+	 * Windows proxy settings as reported by windows WinHTTP API.
+	 *
+	 * @author Drew Mitchell, Copyright 2017
+	 ****************************************************************************/
+
+	private int accessType;
+	private String proxy;
+	private String proxyBypass;
+
+	/*************************************************************************
+	 * Constructor
+	 *
+	 * @param accessType
+	 *            flag that specifies whether or not a proxy is in use
+	 * @param proxy
+	 *            the proxy server selected
+	 * @param proxyBypass
+	 *            the proxy bypass address list
+	 ************************************************************************/
+
+	public WinProxyConfig(int accessType, String proxy, String proxyBypass) {
+		super();
+		this.accessType = accessType;
+		this.proxy = proxy;
+		this.proxyBypass = proxyBypass;
+	}
+
+	/*************************************************************************
+	 * @return Returns the access type flag.
+	 ************************************************************************/
+
+	public int getAccessType() {
+		return accessType;
+	}
+
+	/*************************************************************************
+	 * @return Returns the proxy.
+	 ************************************************************************/
+
+	public String getProxy() {
+		return this.proxy;
+	}
+
+	/*************************************************************************
+	 * @return Returns the proxyBypass.
+	 ************************************************************************/
+
+	public String getProxyBypass() {
+		return this.proxyBypass;
+	}
+
+}


### PR DESCRIPTION
This function checks for proxy settings at the registry (WinHTTP) level, as opposed to the IE search strategy, which checks at the user (WinINet) level. The proxy isn't always set at the WinHTTP level, so Bernd Rosstauscher's fallback was to use the IE search strategy for both, but now both functions are available.