### PR TITLE
upgrade jna dependency from 4.2.2 to 4.5.1 fixing issues #33 and #35

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,12 +78,12 @@
             <dependency>
                 <groupId>net.java.dev.jna</groupId>
                 <artifactId>jna</artifactId>
-                <version>4.2.2</version>
+                <version>4.5.1</version>
             </dependency>
             <dependency>
                 <groupId>net.java.dev.jna</groupId>
                 <artifactId>jna-platform</artifactId>
-                <version>4.2.2</version>
+                <version>4.5.1</version>
             </dependency>
             <dependency>
                 <groupId>junit</groupId>


### PR DESCRIPTION
With 4.3.0 it the jna dll should be linked statically to the MS VC++ dlls