### PR TITLE
Added support for DHCP resolution to WpadProxySearchStrategy

### DIFF
--- a/src/main/java/com/github/markusbernhardt/proxy/ProxySearch.java
+++ b/src/main/java/com/github/markusbernhardt/proxy/ProxySearch.java
@@ -15,6 +15,7 @@ import com.github.markusbernhardt.proxy.search.desktop.kde.KdeProxySearchStrateg
 import com.github.markusbernhardt.proxy.search.desktop.win.WinProxySearchStrategy;
 import com.github.markusbernhardt.proxy.search.env.EnvProxySearchStrategy;
 import com.github.markusbernhardt.proxy.search.java.JavaProxySearchStrategy;
+import com.github.markusbernhardt.proxy.search.wpad.WpadProxySearchStrategy;
 import com.github.markusbernhardt.proxy.selector.misc.BufferedProxySelector;
 import com.github.markusbernhardt.proxy.selector.misc.BufferedProxySelector.CacheScope;
 import com.github.markusbernhardt.proxy.selector.misc.ProxyListFallbackSelector;
@@ -63,6 +64,8 @@ public class ProxySearch implements ProxySearchStrategy {
 	public enum Strategy {
 	    /// Use the platform settings.
 		OS_DEFAULT,
+		/// Use WPAD resolution
+		WPAD,
 		/// Use the settings of the platforms default browser.
 		BROWSER,
 		/// Use Firefox settings
@@ -132,6 +135,9 @@ public class ProxySearch implements ProxySearchStrategy {
 		switch (strategy) {
 		case OS_DEFAULT:
 			this.strategies.add(new DesktopProxySearchStrategy());
+			break;
+		case WPAD:
+			this.strategies.add(new WpadProxySearchStrategy());
 			break;
 		case BROWSER:
 			this.strategies.add(getDefaultBrowserStrategy());

--- a/src/main/java/com/github/markusbernhardt/proxy/search/wpad/WpadProxySearchStrategy.java
+++ b/src/main/java/com/github/markusbernhardt/proxy/search/wpad/WpadProxySearchStrategy.java
@@ -3,13 +3,20 @@ package com.github.markusbernhardt.proxy.search.wpad;
 import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.InetAddress;
+import java.net.NetworkInterface;
 import java.net.Proxy;
 import java.net.ProxySelector;
+import java.net.SocketException;
 import java.net.URL;
 import java.net.UnknownHostException;
+import java.util.Enumeration;
 import java.util.Properties;
+import java.util.Random;
 
 import com.github.markusbernhardt.proxy.ProxySearchStrategy;
+import com.github.markusbernhardt.proxy.search.wpad.dhcp.DHCPMessage;
+import com.github.markusbernhardt.proxy.search.wpad.dhcp.DHCPOptions;
+import com.github.markusbernhardt.proxy.search.wpad.dhcp.DHCPSocket;
 import com.github.markusbernhardt.proxy.util.Logger;
 import com.github.markusbernhardt.proxy.util.Logger.LogLevel;
 import com.github.markusbernhardt.proxy.util.ProxyException;
@@ -166,12 +173,112 @@ public class WpadProxySearchStrategy implements ProxySearchStrategy {
    * Uses DHCP to find the script URL.
    * 
    * @return the URL, null if not found.
+   * @throws IOException 
    ************************************************************************/
 
-  private String detectScriptUrlPerDHCP() {
-    Logger.log(getClass(), LogLevel.DEBUG, "Searching per DHCP not supported yet.");
-    // TODO Rossi 28.04.2009 Not implemented yet.
-    return null;
+  private String detectScriptUrlPerDHCP() throws IOException {
+	  Logger.log(getClass(), LogLevel.TRACE, "Searching per DHCP.");
+	String url = null;
+	try {
+	  Enumeration<NetworkInterface> interfaces = NetworkInterface.getNetworkInterfaces();
+	  while (interfaces.hasMoreElements()) {
+        NetworkInterface network = interfaces.nextElement();
+        if (!network.getName().equals("lo")) {
+          byte[] mac = network.getHardwareAddress();
+          Enumeration<InetAddress> ips = network.getInetAddresses();
+          while (ips.hasMoreElements()) {
+            InetAddress ip = ips.nextElement();
+            // If ip is an IPv4 address
+            if (ip.getAddress().length == 4)
+              url = checkDhcpAckForPAC(ip, mac);
+            if (url != null)
+              return url;
+          }
+        }
+      }
+    } catch (SocketException e) {
+      e.printStackTrace();
+    }
+    return url;
+  }
+  
+  private String getMacString(byte[] mac) {
+    StringBuilder sb = new StringBuilder();
+    for (int i = 0; i < 6; i++)
+      sb.append(String.format("%02X%s", mac[i], (i < 6 - 1) ? ":" : ""));
+    return sb.toString();
   }
 
+  private String checkDhcpAckForPAC(InetAddress ip, byte[] mac) throws IOException {
+    DHCPMessage messageOut = new DHCPMessage(DHCPMessage.SERVER_PORT);
+    DHCPMessage messageIn = new DHCPMessage(DHCPMessage.CLIENT_PORT);
+    DHCPSocket bindSocket = new DHCPSocket(DHCPMessage.CLIENT_PORT, ip);
+    // from DHCPINFORM Message Clarifications
+    // https://tools.ietf.org/html/draft-ietf-dhc-dhcpinform-clarify-06
+
+    // Clients are still required to fulfill the DHCPv4 requirements for
+    // DHCPINFORM messages ([RFC2131], Sections 4.4.1 and 4.4.3). But
+    // the following are clarified as in addition, or to overlay those
+    // requirements:
+    messageOut.setOp((byte) 1); // setup message to send a DCHPREQUEST
+    // Clients MUST set 'ciaddr' to a working IPv4 address which they
+    // can use to receive replies. This address SHOULD be an address
+    // that is currently assigned to the interface upon which the client
+    // is transmitting its DHCPINFORM, except in the condition where the
+    // DHCP client is unable to determine a valid IP address for its
+    // host, in which case the client MUST set 'ciaddr' to all-zero.
+    messageOut.setCiaddr(ip.getAddress());
+    // Clients MUST set 'chaddr', 'htype', and 'hlen' to the hardware
+    // address of the interface upon which the DHCPINFORM message is
+    // being transmitted, except in the condition where the DHCP client
+    // is unable to determine this address, in which case all three
+    // fields MUST be set all-zero.
+    byte[] addr = new byte[16];
+    if (mac != null)
+      for (int i = 0; i < 6; i++)
+        addr[i] = mac[i];
+    // Despite what the spec says above if these are set to 0 you may
+    // not get a response from some dhcp servers
+    messageOut.setHtype((byte) 1); // 1 for Ethernet
+    messageOut.setHlen((byte) 6); // 6 for IEEE 802 MAC addresses
+    messageOut.setChaddr(addr);
+    // Clients MUST set the 'flags' field to zero. This means that the
+    // client MUST NOT set the 'BROADCAST' flag, and MUST be capable of
+    // receiving IP unicasts.
+    messageOut.setFlags((short) 0);
+    messageOut.setHops((byte) 0);
+    messageOut.setXid(new Random().nextInt());
+    messageOut.setSecs((short) 0);
+    messageOut.setYiaddr(InetAddress.getByName("0.0.0.0").getAddress());
+    messageOut.setSiaddr(InetAddress.getByName("0.0.0.0").getAddress());
+    messageOut.setGiaddr(InetAddress.getByName("0.0.0.0").getAddress());
+
+    // From RFC 2131 Section 4.4 Table 5
+    // https://tools.ietf.org/html/rfc2131#section-4.4
+    // Looks like the only option we need to set for a DHCPINFORM
+    // message is the DHCP message type
+    messageOut.setOption(DHCPOptions.OPTION_DHCP_MESSAGE_TYPE, new byte[] { DHCPMessage.DHCPINFORM });
+    Logger.log(getClass(), LogLevel.TRACE, "Trying DHCPInform on " + ip.getHostAddress() + (mac != null ? (" @ " + getMacString(mac)) : ""));
+    bindSocket.send(messageOut);
+    boolean sentinal = true;
+    while (sentinal) {
+      if (bindSocket.receive(messageIn)) {
+        if (messageOut.getXid() == messageIn.getXid()) {
+          byte[] pacFileLocationRaw = messageIn.getOption(DHCPOptions.OPTION_PROXY_AUTODISCOVERY);
+          String pacFileLocation = null;
+          if (pacFileLocationRaw != null)
+            pacFileLocation = new String(pacFileLocationRaw);
+          bindSocket.close();
+          return pacFileLocation;
+        } else {
+          bindSocket.send(messageOut);
+        }
+      } else {
+        Logger.log(getClass(), LogLevel.DEBUG, "Timed out.");
+        sentinal = false;
+      }
+    }
+    bindSocket.close();
+    return null;
+  }
 }

--- a/src/main/java/com/github/markusbernhardt/proxy/search/wpad/dhcp/DHCPOptions.java
+++ b/src/main/java/com/github/markusbernhardt/proxy/search/wpad/dhcp/DHCPOptions.java
@@ -82,6 +82,8 @@ public class DHCPOptions {
 	public static final int OPTION_DHCP_REBIND_TIME = 59;
 	public static final int OPTION_DHCP_CLASS_IDENTIFIER = 60;
 	public static final int OPTION_DHCP_CLIENT_IDENTIFIER = 61;
+	
+	public static final int OPTION_PROXY_AUTODISCOVERY = 252;
 
 	/**
 	 * This inner class represent an entry in the Option Table

--- a/src/main/java/com/github/markusbernhardt/proxy/search/wpad/dhcp/DHCPSocket.java
+++ b/src/main/java/com/github/markusbernhardt/proxy/search/wpad/dhcp/DHCPSocket.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.net.DatagramPacket;
 import java.net.DatagramSocket;
 import java.net.InetAddress;
+import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.net.SocketException;
 import java.net.UnknownHostException;
@@ -41,6 +42,22 @@ public class DHCPSocket extends DatagramSocket {
 	 */
 	public DHCPSocket(int inPort) throws SocketException {
 		super(inPort);
+		setSoTimeout(this.SOCKET_TIMEOUT);
+	}
+
+	/**
+	 * Constructor for creating DHCPSocket on a specific local address and port
+	 * on the local machine.
+	 * 
+	 * @param inPort
+	 *            The port for the application to bind.
+	 * @param lAddr
+	 *            The local address for the application to bind.
+	 * @throws SocketException
+	 *             As thrown by the {@link Socket} constructor
+	 */
+	public DHCPSocket(int inPort, InetAddress lAddr) throws SocketException {
+		super(inPort, lAddr);
 		setSoTimeout(this.SOCKET_TIMEOUT);
 	}
 


### PR DESCRIPTION
Made a couple minor changes to the DHCPSocket and DHCPOptions classes to
make them able to handle Option 252 and capable of sending on a specific
interface. Then used them to send DHCPInform messages on all interfaces
with valid IPv4 addresses and check the responses for Option 252. Also
added WPAD to the Strategy enum so it can be tested with ProxyTester and
added as a Strategy.