### PR TITLE
Wrong interpretation of the return value of the FindProxyForURL.

### DIFF
--- a/src/main/java/com/github/markusbernhardt/proxy/selector/pac/PacProxySelector.java
+++ b/src/main/java/com/github/markusbernhardt/proxy/selector/pac/PacProxySelector.java
@@ -155,21 +155,20 @@ public class PacProxySelector extends ProxySelector {
    ************************************************************************/
 
   private Proxy buildProxyFromPacResult(String pacResult) {
-    if (pacResult.trim().length() < 6) {
-      return Proxy.NO_PROXY;
-    }
-    String proxyDef = pacResult.trim();
-    if (proxyDef.toUpperCase().startsWith(PAC_DIRECT)) {
-      return Proxy.NO_PROXY;
-    }
+    String[] words = pacResult.trim().split("\\s+");
+
+    if (words.length == 0) return Proxy.NO_PROXY;
+    if (words.length == 1) return Proxy.NO_PROXY;
+
+    String proxyType = words[0];
+    String host  = concat(words,1);
 
     // Check proxy type.
     Proxy.Type type = Proxy.Type.HTTP;
-    if (proxyDef.toUpperCase().startsWith(PAC_SOCKS)) {
+    if (proxyType.toUpperCase().startsWith(PAC_SOCKS)) {
       type = Proxy.Type.SOCKS;
     }
 
-    String host = proxyDef.substring(6);
     Integer port = ProxyUtil.DEFAULT_PROXY_PORT;
 
     // Split port from host
@@ -183,5 +182,12 @@ public class PacProxySelector extends ProxySelector {
     SocketAddress adr = InetSocketAddress.createUnresolved(host, port);
     return new Proxy(type, adr);
   }
+  private static String concat(String[] strings, int startIndex){
+    StringBuilder b = new StringBuilder();
+    for (int i = startIndex; i < strings.length; i++) {
+      b.append(strings[i]);
+    }
+    return b.toString();
 
+  }
 }

--- a/src/test/java/com/github/markusbernhardt/proxy/selector/pac/PacProxySelectorTest.java
+++ b/src/test/java/com/github/markusbernhardt/proxy/selector/pac/PacProxySelectorTest.java
@@ -116,6 +116,27 @@ public class PacProxySelectorTest {
 	}
 
 	/*************************************************************************
+	 * Test method
+	 *
+	 * @throws ProxyException
+	 *             on proxy detection error.
+	 * @throws MalformedURLException
+	 *             on URL erros
+	 ************************************************************************/
+	@Test
+	public void testScriptProxyTypes() throws ProxyException, MalformedURLException {
+		PacProxySelector pacProxySelector = new PacProxySelector(new UrlPacScriptSource(toUrl("testProxyTypes.pac")));
+		List<Proxy> result = pacProxySelector.select(TestUtil.HTTP_TEST_URI);
+		assertEquals(6, result.size());
+		assertEquals(new Proxy(Type.HTTP, InetSocketAddress.createUnresolved("my-proxy.com", 80)), result.get(0));
+		assertEquals(new Proxy(Type.HTTP, InetSocketAddress.createUnresolved("my-proxy2.com", 80)), result.get(1));
+		assertEquals(new Proxy(Type.HTTP, InetSocketAddress.createUnresolved("my-proxy3.com", 486)), result.get(2));
+		assertEquals(new Proxy(Type.SOCKS, InetSocketAddress.createUnresolved("my-proxy4.com", 80)), result.get(3));
+		assertEquals(new Proxy(Type.SOCKS, InetSocketAddress.createUnresolved("my-proxy5.com", 80)), result.get(4));
+		assertEquals(new Proxy(Type.SOCKS, InetSocketAddress.createUnresolved("my-proxy6.com", 80)), result.get(5));
+	}
+
+	/*************************************************************************
 	 * Test method for the override local IP feature.
 	 * 
 	 * @throws ProxyException

--- a/src/test/resources/pac/testProxyTypes.pac
+++ b/src/test/resources/pac/testProxyTypes.pac
@@ -1,0 +1,4 @@
+function FindProxyForURL(url, host)
+{
+    return "PROXY  my-proxy.com:80 ; HTTP my-proxy2.com: 80; HTTPS my-proxy3.com :486; SOCKS my-proxy4.com:80; SOCKS4 my-proxy5.com:80;  SOCKS5 my-proxy6.com:80;";
+}


### PR DESCRIPTION
Corrected wrong interpretation of the return value of the FindProxyForURL function (value with the proxy type 'HTTP').

When FindProxyForURL returned a string with proxy type ”HTTP", the PacProxySelector truncates the first character of the host name following the Proxy type, because it simply assumes the host name begins at the 7th character of the returned value.    