### PR TITLE
Fix broken transetive com.sun.tools dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -97,7 +97,7 @@
       <dependency>
         <groupId>org.javadelight</groupId>
         <artifactId>delight-nashorn-sandbox</artifactId>
-        <version>0.1.14</version>
+        <version>0.1.18</version>
       </dependency>
       <dependency>
         <groupId>org.slf4j</groupId>


### PR DESCRIPTION
Bumps delight-nashorn-sandbox from 0.1.14 to 0.1.18. Latest version would be 0.1.25 https://github.com/javadelight/delight-nashorn-sandbox#user-content-version-history - but I am not sure about the other changes past 0.1.18 so I thought to play it safe.